### PR TITLE
Added timeframe start/end for poll objects

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -65,6 +65,6 @@ class PollsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def poll_params
-      params.require(:poll).permit(:title)
+      params.require(:poll).permit(:title, :timeframe_start, :timeframe_end)
     end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -2,4 +2,11 @@ class Poll < ApplicationRecord
   validates :title, presence: true
   validates :timeframe_start, presence: true
   validates :timeframe_end, presence: true
+  validate :validateTimeframe
+
+  def validateTimeframe
+    if timeframe_start.nil? || timeframe_end.nil? || (timeframe_start > timeframe_end)
+      errors.add(:timeframe_start, "must be before end time")
+    end
+  end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -1,3 +1,5 @@
 class Poll < ApplicationRecord
   validates :title, presence: true
+  validates :timeframe_start, presence: true
+  validates :timeframe_end, presence: true
 end

--- a/app/views/polls/_form.html.erb
+++ b/app/views/polls/_form.html.erb
@@ -15,6 +15,14 @@
     <%= form.label :title %>
     <%= form.text_field :title %>
   </div>
+  <div class="field">
+    <%= form.label :timeframe_start %>
+    <%= form.text_field :timeframe_start %>
+  </div>
+  <div class="field">
+    <%= form.label :timeframe_end %>
+    <%= form.text_field :timeframe_end %>
+  </div>
 
   <div class="actions">
     <%= form.submit %>

--- a/app/views/polls/_poll.json.jbuilder
+++ b/app/views/polls/_poll.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! poll, :id, :title, :created_at, :updated_at
+json.extract! poll, :id, :title, :created_at, :updated_at, :timeframe_start, :timeframe_end
 json.url poll_url(poll, format: :json)

--- a/app/views/polls/index.html.erb
+++ b/app/views/polls/index.html.erb
@@ -14,6 +14,8 @@
     <% @polls.each do |poll| %>
       <tr>
         <td><%= poll.title %></td>
+        <td><%= poll.timeframe_start %></td>
+        <td><%= poll.timeframe_end %></td>
         <td><%= link_to 'Show', poll %></td>
         <td><%= link_to 'Edit', edit_poll_path(poll) %></td>
         <td><%= link_to 'Destroy', poll, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -4,6 +4,15 @@
   <strong>Title:</strong>
   <%= @poll.title %>
 </p>
+<p>
+  Start:
+  <%= @poll.timeframe_start%>
+</p>
+<p>
+  End:
+  <%= @poll.timeframe_end%>
+</p>
+
 
 <%= link_to 'Edit', edit_poll_path(@poll) %> |
 <%= link_to 'Back', polls_path %>

--- a/db/migrate/20210217005553_add_start_stop_to_poll.rb
+++ b/db/migrate/20210217005553_add_start_stop_to_poll.rb
@@ -1,0 +1,6 @@
+class AddStartStopToPoll < ActiveRecord::Migration[6.1]
+  def change
+    add_column :polls, :timeframe_start, :datetime
+    add_column :polls, :timeframe_end, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_16_042605) do
+ActiveRecord::Schema.define(version: 2021_02_17_005553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,8 @@ ActiveRecord::Schema.define(version: 2021_02_16_042605) do
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "timeframe_start"
+    t.datetime "timeframe_end"
   end
 
 end

--- a/test/controllers/polls_controller_test.rb
+++ b/test/controllers/polls_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PollsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @poll = polls(:one)
+    @poll = polls(:poll)
   end
 
   test "should get index" do
@@ -17,7 +17,7 @@ class PollsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create poll" do
     assert_difference('Poll.count') do
-      post polls_url, params: { poll: { title: @poll.title } }
+      post polls_url, params: { poll: { title: @poll.title, timeframe_start: @poll.timeframe_start, timeframe_end: @poll.timeframe_end } }
     end
 
     assert_redirected_to poll_url(Poll.order("created_at ASC").last)
@@ -34,7 +34,7 @@ class PollsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update poll" do
-    patch poll_url(@poll), params: { poll: { title: @poll.title } }
+    patch poll_url(@poll), params: { poll: { title: @poll.title, timeframe_start: @poll.timeframe_start, timeframe_end: @poll.timeframe_end } }
     assert_redirected_to poll_url(@poll)
   end
 
@@ -44,5 +44,33 @@ class PollsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to polls_url
+  end
+
+  test "should fail on blank start time" do
+    post polls_url, params: { poll: { title: @poll.title, timeframe_start: nil, timeframe_end: @poll.timeframe_end } }
+    assert_equal 422, status
+  end
+
+  test "should fail on blank end time" do
+    post polls_url, params: { poll: { title: @poll.title, timeframe_start: @poll.timeframe_start, timeframe_end: nil } }
+    assert_equal 422, status
+  end
+
+
+  test "should fail on invalid start time" do
+    post polls_url, params: { poll: { title: @poll.title, timeframe_start: "invalid start", timeframe_end: @poll.timeframe_end } }
+    assert_equal 422, status
+  end
+
+
+  test "should fail on invalid end time" do
+    post polls_url, params: { poll: { title: @poll.title, timeframe_start: @poll.timeframe_start, timeframe_end: "invalid end" } }
+    assert_equal 422, status
+  end
+
+
+  test "should fail on start time after end time" do
+    post polls_url, params: { poll: { title: @poll.title, timeframe_start: @poll.timeframe_end, timeframe_end: @poll.timeframe_start } }
+    assert_equal 422, status
   end
 end

--- a/test/fixtures/polls.yml
+++ b/test/fixtures/polls.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
+poll:
   title: MyString
+  timeframe_start: 1999-01-08 04:05:06
+  timeframe_end: 1999-01-08 04:05:07
 
-two:
-  title: MyString


### PR DESCRIPTION
- Added DB migration to add SQL DateTime type for `timeframe_start` and `timeframe_end`.
- Modified views with start/end time input fields and their displays
- Checks valid start/end date time format before entry validation
- Validate form fields
- New tests for valid and invalid time inputs, modified polls fixture with new timeframe fields

Note: timeframe inputs should be in ISO 8601 format.